### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/ghp-deployment.yml
+++ b/.github/workflows/ghp-deployment.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   pages: write
+  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.


### PR DESCRIPTION
Last deployment failed because of missing `id-token` permissions. This PR tries to fix that.

https://github.com/hemilabs/vusd-landing/actions/runs/15281005317/job/42979758673